### PR TITLE
Add docker support for running the MIDS Calculator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM rocker/r-ver:4.2
+
+EXPOSE 3000
+
+# install R packages we need
+RUN install2.r --error \
+    shiny \
+    shinyBS \
+    ggplot2 \
+    DT \
+    shinyjs \
+    sortable \
+    shinybusy \
+    generics \
+    tidyselect \
+    data.table \
+    purrr \
+    dplyr
+
+
+# just copy the whole lot
+COPY . /usr/local/src/MIDSCalculator
+
+WORKDIR /usr/local/src/MIDSCalculator
+
+CMD ["Rscript", "dockerApp.R"]

--- a/dockerApp.R
+++ b/dockerApp.R
@@ -6,4 +6,4 @@
 
 library(shiny)
 folder_address = paste0(getwd(),"/src/Shiny_MIDS/MIDScalcApp.R")
-runApp(folder_address, launch.browser=F, port=3000)
+runApp(folder_address, launch.browser=F, host='0.0.0.0', port=3000)

--- a/dockerApp.R
+++ b/dockerApp.R
@@ -1,0 +1,9 @@
+################################################################################
+# This script is the same as the app.R script but with a few different options #
+# passed to runApp so that running the app from inside a docker container is   #
+# easier.                                                                      #
+################################################################################
+
+library(shiny)
+folder_address = paste0(getwd(),"/src/Shiny_MIDS/MIDScalcApp.R")
+runApp(folder_address, launch.browser=F, port=3000)


### PR DESCRIPTION
The image has all the R packages necessary installed and then the container just launches the shiny app through the new `dockerApp.R` script.

To use:

```bash
# build the container (run from the repo root)
docker build -t midscalculator .

# run the container
docker run -p 3000:3000 midscalculator
```